### PR TITLE
feat:Showing Pending Actions

### DIFF
--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -2,7 +2,38 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('MOM', {
-	// refresh: function(frm) {
-
-	// }
+	review_pending_actions:function(frm){
+		if(frm.doc.review_pending_actions && frm.doc.project){
+			show_pending_actions(frm);
+		}
+		else{
+			frm.clear_table('pending_actions');
+		}
+	},
+	project:function(frm){
+		frm.clear_table('pending_actions');
+		frm.set_value('review_pending_actions', 0)
+	}
 });
+
+let show_pending_actions = function (frm){
+	/*  to show pending tasks
+		output: appending pending_actions child table with uncompleted tasks 
+	*/
+	frappe.call({
+		method: 'minom.minutes_of_meeting.doctype.mom.mom.get_pending_actions',
+		args:{
+			'project' : frm.doc.project,
+		},
+		callback:function(r){
+			r.message.forEach(function(i){
+				frm.add_child('pending_actions', {
+					subject: i.subject,
+					priority: i.priority,
+					description: i.description.replace(/(<([^>]+)>)/gi, '')
+				})
+				frm.refresh_fields();
+			})
+		}
+	})
+}

--- a/minom/minutes_of_meeting/doctype/mom/mom.py
+++ b/minom/minutes_of_meeting/doctype/mom/mom.py
@@ -1,8 +1,18 @@
 # Copyright (c) 2022, efeone Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class MOM(Document):
 	pass
+
+
+@frappe.whitelist()
+def get_pending_actions(project):
+	'''getting uncompleted tasks
+	   output : list of uncompleted tasks according to the project
+	'''
+	return frappe.get_all('Task', filters = {'project': project, 'status': ['!=' , 'Completed']}, fields = ['subject', 'priority', 'description'])
+	
+	


### PR DESCRIPTION
## Feature description
appending Pending Actions child table with uncompleted tasks 

## Analysis and design (optional)
tasks list
![Screenshot from 2022-08-16 11-56-36](https://user-images.githubusercontent.com/105269688/184815569-86b4dd49-9cc5-47f1-9c2a-d9c6be67152e.png)

![Screenshot from 2022-08-16 11-56-57](https://user-images.githubusercontent.com/105269688/184815587-dc533c98-ac33-4ea6-a54e-d5d5793a8ed7.png)
pending actions child table
![Screenshot from 2022-08-16 11-57-02](https://user-images.githubusercontent.com/105269688/184815601-1082bf4e-b2d3-457d-beac-911995676065.png)


## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
