### PR TITLE
feat:Showing Pending tasks

### DIFF
--- a/minom/minutes_of_meeting/doctype/actions_taken/actions_taken.json
+++ b/minom/minutes_of_meeting/doctype/actions_taken/actions_taken.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "task",
   "subject",
   "column_break_2",
   "priority",
@@ -39,12 +40,19 @@
   {
    "fieldname": "section_break_4",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "label": "Task",
+   "options": "Task",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-12 14:25:05.455616",
+ "modified": "2022-08-16 13:34:38.236440",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "Actions Taken",

--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -2,7 +2,46 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('MOM', {
-	// refresh: function(frm) {
-
-	// }
+	review_pending_actions:function(frm){
+		if(frm.doc.review_pending_actions && !frm.doc.project){
+			frappe.msgprint({
+				title: __('Notification'),
+				indicator: 'red',
+				message: __('Select a project to show pending actions')
+			});
+		}
+		else if(frm.doc.review_pending_actions && frm.doc.project){
+			show_pending_actions(frm);
+		}
+		else{
+			frm.clear_table('pending_actions');
+		}
+	},
+	project:function(frm){
+		frm.clear_table('pending_actions');
+		frm.set_value('review_pending_actions', 0)
+	}
 });
+
+let show_pending_actions = function (frm){
+	/*  to show pending tasks
+		output: appending pending_actions child table with uncompleted tasks 
+	*/
+	frappe.call({
+		method: 'minom.minutes_of_meeting.doctype.mom.mom.get_pending_actions',
+		args:{
+			'project' : frm.doc.project,
+		},
+		callback:function(r){
+			r.message.forEach(function(i){
+				frm.add_child('pending_actions', {
+					subject: i.subject,
+					task: i.name,
+					priority: i.priority,
+					description: i.description.replace(/(<([^>]+)>)/gi, '')
+				})
+				frm.refresh_fields();
+			})
+		}
+	})
+}

--- a/minom/minutes_of_meeting/doctype/mom/mom.py
+++ b/minom/minutes_of_meeting/doctype/mom/mom.py
@@ -1,8 +1,18 @@
 # Copyright (c) 2022, efeone Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class MOM(Document):
 	pass
+
+
+@frappe.whitelist()
+def get_pending_actions(project):
+	'''getting uncompleted tasks
+	   output : list of uncompleted tasks according to the project
+	'''
+	return frappe.get_all('Task', filters = {'project': project, 'status': ['!=' , 'Completed']}, fields = ['name', 'subject', 'priority', 'description'])
+	
+	


### PR DESCRIPTION
## Feature description
appending Pending Actions child table with uncompleted tasks
added a field in child table named task for linking taks

## Analysis and design (optional)
pending actions table
![Screenshot from 2022-08-16 14-21-30](https://user-images.githubusercontent.com/105269688/184843696-57f41f72-d63d-42dd-ad20-011febbe5c32.png)

![Screenshot from 2022-08-16 14-21-26](https://user-images.githubusercontent.com/105269688/184843822-e1b2b516-0c7f-451e-836f-d73e301a4754.png)


## Is there any existing behavior change of other features due to this code change? 
No.

## Was this feature tested on the browsers?
  - Chrome
