### PR TITLE
feat:Show last MOM Actions and Attendees on demand in the MOM

### DIFF
--- a/minom/minutes_of_meeting/doctype/attendees/attendees.json
+++ b/minom/minutes_of_meeting/doctype/attendees/attendees.json
@@ -19,6 +19,7 @@
    "options": "User"
   },
   {
+   "fetch_from": "user.full_name",
    "fieldname": "full_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -35,7 +36,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-12 15:55:02.215064",
+ "modified": "2022-08-16 10:20:42.160744",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "Attendees",

--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -2,7 +2,8 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('MOM', {
-	review_pending_actions:function(frm){
+
+	review_pending_actions: function(frm) {
 		if(frm.doc.review_pending_actions && !frm.doc.project){
 			frappe.msgprint({
 				title: __('Notification'),
@@ -17,13 +18,78 @@ frappe.ui.form.on('MOM', {
 			frm.clear_table('pending_actions');
 		}
 	},
-	project:function(frm){
+
+	project: function(frm) {
 		frm.clear_table('pending_actions');
-		frm.set_value('review_pending_actions', 0)
+		frm.clear_table('last_attendees');
+		frm.clear_table('last_actions');
+		frm.set_value('review_pending_actions', 0);
+		frm.set_value('review_last_mom', 0);
+	},
+
+	from_time: function(frm) {
+		if(frm.doc.to_time)
+			calculate_time(frm);
+	},
+
+	to_time: function(frm) {
+		if(frm.doc.from_time) 	
+			calculate_time(frm);
+	},
+
+	review_last_mom: function (frm) {
+		if (frm.doc.review_last_mom) {
+			frm.call('get_last_mom')
+		}
+		else{
+			frm.clear_table('last_attendees');
+			frm.clear_table('last_actions');
+		}
 	}
+
 });
 
-let show_pending_actions = function (frm){
+
+frappe.ui.form.on('Attendees', {
+	user(frm, cdt, cdn) {
+		set_filters(frm);
+	}
+})
+
+let calculate_time = function(frm) {
+	/*
+		to calculate meeting duration
+		output : meeting duration in minutes in meeting_duration field
+	*/
+	let to_time = new Date(frm.doc.to_time)
+	let from_time = new Date(frm.doc.from_time)
+	let duration = ((to_time.getTime() - from_time.getTime())/1000)/60
+	frm.set_value('meeting_duration', duration)
+}
+
+let set_filters = function(frm) {
+	/*	setting filter for user field in attendees child table	*/
+	if (frm.doc.attendees) {
+		let attendees = '';
+		frm.doc.attendees.forEach(function (attendee, i) {
+			if (i === 0) {
+				attendees += attendee.user;
+			}
+			else {
+				attendees += ', ' + attendee.user;
+			}
+		});
+		frm.set_query('user', 'attendees', function (doc, cdt, cdn) {
+			return {
+				filters: {
+					name: ['not in', attendees]
+				}
+			}
+		});
+	}
+}
+
+let show_pending_actions = function (frm) {
 	/*  to show pending tasks
 		output: appending pending_actions child table with uncompleted tasks 
 	*/

--- a/minom/minutes_of_meeting/doctype/mom/mom.json
+++ b/minom/minutes_of_meeting/doctype/mom/mom.json
@@ -1,11 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "naming_series:",
  "creation": "2022-08-12 15:34:31.373866",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "project",
   "discussion_topic",
   "from_time",
@@ -22,7 +24,7 @@
   "last_mom_review_section",
   "review_last_mom",
   "last_mom_name",
-  "section_break_15",
+  "last_attendees",
   "last_actions",
   "pending_actions_section",
   "review_pending_actions",
@@ -143,10 +145,6 @@
    "options": "Actions Taken"
   },
   {
-   "fieldname": "section_break_15",
-   "fieldtype": "Section Break"
-  },
-  {
    "depends_on": "eval:doc.review_last_mom",
    "fieldname": "last_actions",
    "fieldtype": "Table",
@@ -165,12 +163,25 @@
    "fieldtype": "Data",
    "label": "Project Name",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.review_last_mom",
+   "fieldname": "last_attendees",
+   "fieldtype": "Table",
+   "label": "Last Attendees",
+   "options": "Attendees"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "MOM-.YY.-"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-08-12 16:59:32.602481",
+ "modified": "2022-08-16 12:33:44.002899",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "MOM",

--- a/minom/minutes_of_meeting/doctype/mom/mom.py
+++ b/minom/minutes_of_meeting/doctype/mom/mom.py
@@ -5,7 +5,42 @@ import frappe
 from frappe.model.document import Document
 
 class MOM(Document):
-	pass
+	@frappe.whitelist()
+	def get_last_mom(self):
+		'''
+			getting last MOM doc of the selected project
+		   	output : Attendees and Actions taken in the last meeting
+		'''
+		if self.project:
+			check = frappe.db.exists('MOM', { 'project': self.project})
+			if check:
+				last_mom = frappe.get_last_doc('MOM', filters = {'project':self.project})
+				for i in last_mom.attendees:
+					if(i.attended):
+						self.append('last_attendees', {
+							'user': i.user,
+							'full_name': i.full_name,
+							'attended': i.attended
+						})
+				
+				for i in last_mom.actions:
+					self.append('last_actions', {
+						'subject': i.subject,
+						'priority': i.priority,
+						'description': i.description
+					})			
+			else:
+				frappe.msgprint(
+					msg = 'There are no MOMs for the Selected Project',
+					title = 'Notification'
+				)
+				self.review_last_mom = 0
+		else:
+			frappe.msgprint(
+					msg = 'Select a Project to fetch it\'s last MOM',
+					title = 'Notification'
+				)
+			self.review_last_mom = 0
 
 
 @frappe.whitelist()
@@ -14,5 +49,3 @@ def get_pending_actions(project):
 	   output : list of uncompleted tasks according to the project
 	'''
 	return frappe.get_all('Task', filters = {'project': project, 'status': ['!=' , 'Completed']}, fields = ['name', 'subject', 'priority', 'description'])
-	
-	


### PR DESCRIPTION
## Feature description
1. Added a filter for user and 'fetch from' for full name in Attendees Child Table in MOM
2. Show last MOM Actions and Attendees on demand in the MOM (Task Link : https://erp.efeone.com/app/task/TASK-2022-00198 )
    - Added a 'Last Attendees' Child table in MOM doctype
3. Added a naming series for MOM 
4. Function to calculate meeting duration

## Output screenshots (optional)
1. Added a filter for user and 'fetch from' for full name in Attendees Child Table in MOM
![Screenshot from 2022-08-16 13-13-23](https://user-images.githubusercontent.com/91651425/184825600-61d17bbb-28c4-4598-a824-aba9777976cf.png)

2. Show last MOM Actions and Attendees on demand in the MOM
![Screenshot from 2022-08-16 13-11-14](https://user-images.githubusercontent.com/91651425/184825894-370d2f8d-2b27-4d78-97b0-dc244e5de71b.png)

3. Added a naming series for MOM and Function to calculate meeting duration
![Screenshot from 2022-08-16 13-10-22](https://user-images.githubusercontent.com/91651425/184826088-7d8ae0fa-f072-43ad-9d2e-5812c1b14738.png)


## Areas affected and ensured
1. MOM doctype
2. Attendees Child Table

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
