### PR TITLE
fix:message to user if no pending tasks

### DIFF
--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -10,6 +10,7 @@ frappe.ui.form.on('MOM', {
 				indicator: 'red',
 				message: __('Select a project to show pending actions')
 			});
+			frm.set_value('review_pending_actions', 0);
 		}
 		else if (frm.doc.review_pending_actions && frm.doc.project) {
 			show_pending_actions(frm);
@@ -119,21 +120,35 @@ let show_pending_actions = function (frm) {
 	/*  to show pending tasks
 		output: appending pending_actions child table with uncompleted tasks 
 	*/
+	var description = '';
 	frappe.call({
 		method: 'minom.minutes_of_meeting.doctype.mom.mom.get_pending_actions',
 		args: {
 			'project': frm.doc.project,
 		},
 		callback: function (r) {
-			r.message.forEach(function (i) {
-				frm.add_child('pending_actions', {
-					subject: i.subject,
-					task: i.name,
-					priority: i.priority,
-					description: i.description.replace(/(<([^>]+)>)/gi, '')
+			if(r.message && r.message.length){
+				r.message.forEach(function (i) {
+					if (i.description){
+						description = i.description.replace(/(<([^>]+)>)/gi, '')
+					}	
+					frm.add_child('pending_actions', {
+						subject: i.subject,
+						task: i.name,
+						priority: i.priority,
+						description: description
+					})
 				})
-				frm.refresh_fields();
-			})
+				frm.refresh_fields('pending_actions');
+			}
+			else{
+				frappe.msgprint({
+					title: __('Notification'),
+					indicator: 'green',
+					message: __('Nothing to show')
+				});
+				frm.set_value('review_pending_actions', 0);
+			}	
 		}
 	})
 }


### PR DESCRIPTION
## Feature description
message to the user when checking review_pending_actions if no pending actions available  
condition added for description of task
## Analysis and design (optional)
![Screenshot from 2022-08-17 15-50-16](https://user-images.githubusercontent.com/105269688/185096530-52bb1056-5ac4-4b21-8e1e-284568d28845.png)


## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome

