### PR TITLE
feat:create task against every subject while submitting MOM

### DIFF
--- a/minom/minutes_of_meeting/doctype/mom/mom.py
+++ b/minom/minutes_of_meeting/doctype/mom/mom.py
@@ -3,11 +3,21 @@
 
 from tabnanny import check
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class MOM(Document):
-    pass
+	def on_submit(self):
+		if self.project:#create task aginst subject while submitting MOM
+			for actions_list in self.actions:
+				mom_doc = frappe.new_doc('Task')
+				mom_doc.project = self.project
+				mom_doc.subject = actions_list.subject
+				mom_doc.priority = actions_list.priority
+				mom_doc.description = actions_list.description
+				mom_doc.save()
+			frappe.msgprint(_('Task is created'), alert=True)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
create task against every subject while submitting MOM
![Screenshot from 2022-08-18 11-33-23](https://user-images.githubusercontent.com/96868625/185305932-bd57dbbe-c335-4f3e-bed8-67d626993e11.png)
![Screenshot from 2022-08-18 11-34-02](https://user-images.githubusercontent.com/96868625/185305960-1f8821f5-29e7-428f-a895-d32dac48d74f.png)
![Screenshot from 2022-08-18 11-34-10](https://user-images.githubusercontent.com/96868625/185305987-e8c1402d-c141-4a79-8f8f-0d97b122ff6a.png)


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Safari
