### PR TITLE
feat:Reminder if MOM Followup is not closed within 24 hours

### DIFF
--- a/minom/hooks.py
+++ b/minom/hooks.py
@@ -106,23 +106,23 @@ app_license = "MIT"
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
-# 	"all": [
-# 		"minom.tasks.all"
-# 	],
-# 	"daily": [
-# 		"minom.tasks.daily"
-# 	],
-# 	"hourly": [
-# 		"minom.tasks.hourly"
-# 	],
-# 	"weekly": [
-# 		"minom.tasks.weekly"
-# 	]
-# 	"monthly": [
-# 		"minom.tasks.monthly"
-# 	]
-# }
+scheduler_events = {
+	# "all": [
+	# 	"minom.tasks.all"
+	# ],
+	# "daily": [
+	# 	"minom.tasks.daily"
+	# ],
+	"hourly": [
+		"minom.minutes_of_meeting.utils.send_mom_followup_notif"
+	]
+	# "weekly": [
+	# 	"minom.tasks.weekly"
+	# ],
+	# "monthly": [
+	# 	"minom.tasks.monthly"
+	# ]
+}
 
 # Testing
 # -------

--- a/minom/minutes_of_meeting/utils.py
+++ b/minom/minutes_of_meeting/utils.py
@@ -1,0 +1,29 @@
+import frappe
+from datetime import datetime
+from frappe.utils import time_diff
+
+
+@frappe.whitelist()
+def send_mom_followup_notif():
+    mom_follow_ups = frappe.db.get_all(
+        'MOM Followup', fields=['name', 'date', 'status_of_followup', 'user', 'supervisor'])
+    for mom_followup in mom_follow_ups:
+        if (mom_followup.status_of_followup == 'Pending'):
+            followup_date = mom_followup.date
+            now = datetime.now()
+            if (time_diff(now, followup_date).days >= 1):
+                create_momf_pending_notification(mom_followup.name, mom_followup.user)
+                create_momf_pending_notification(mom_followup.name, mom_followup.supervisor)
+
+
+@frappe.whitelist()
+def create_momf_pending_notification(mom_followup_id, recepient):
+    mom_followup = frappe.get_doc('MOM Followup', mom_followup_id)
+    notification_log = frappe.new_doc('Notification Log')
+    notification_log.type = 'Alert'
+    notification_log.subject = mom_followup.name + ' is Pending'
+    notification_log.email_content = 'MOM Followup with id ' + mom_followup.name + ' of ' + mom_followup.mom + ' is still Pending. Take actions to Complete it ASAP.'
+    notification_log.document_type = mom_followup.doctype
+    notification_log.document_name = mom_followup.name
+    notification_log.for_user = recepient
+    notification_log.save(ignore_permissions=True)


### PR DESCRIPTION
## Feature description
- Sending Reminder to Supervisors and Employees if an MOM Followup is not closed within 24 hours.

## Output screenshots (optional)
- Notification Log :
![Screenshot from 2022-08-22 17-30-19](https://user-images.githubusercontent.com/91651425/185916482-cd7154f8-2ff2-4489-bbf9-5bde4471c53f.png)

## Areas affected and ensured
- Hooks

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
