### PR TITLE
Task 00209

### DIFF
--- a/minom/minutes_of_meeting/doctype/actions_taken/actions_taken.json
+++ b/minom/minutes_of_meeting/doctype/actions_taken/actions_taken.json
@@ -11,14 +11,16 @@
   "column_break_2",
   "priority",
   "section_break_4",
-  "description"
+  "description",
+  "need_follow_up"
  ],
  "fields": [
   {
    "fieldname": "subject",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Subject"
+   "label": "Subject",
+   "reqd": 1
   },
   {
    "fieldname": "priority",
@@ -47,12 +49,19 @@
    "label": "Task",
    "options": "Task",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "need_follow_up",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Need Follow Up"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-16 13:34:38.236440",
+ "modified": "2022-08-23 11:49:40.068777",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "Actions Taken",

--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2022, efeone Pvt. Ltd. and contributors
 // For license information, please see license.txt
-
 frappe.ui.form.on('MOM', {
 	
 	refresh: function (frm) {
@@ -98,9 +97,20 @@ frappe.ui.form.on('MOM', {
 		else{ 
 			show_users(frm);
 		}
+	},
+
+	follow_up_needed: function (frm){
+		if(!frm.doc.user){
+			frm.set_value( 'user', frappe.session.user ); //setting value for user field as current user
+		};
 	}
 });
 
+frappe.ui.form.on('Actions Taken', {
+	need_follow_up: function (frm, cdt, cdn) {
+		mom_follow_up(frm, cdt, cdn);
+	}
+});
 
 frappe.ui.form.on('Attendees', {
 	user(frm, cdt, cdn) {
@@ -275,3 +285,25 @@ let add_custom_button_for_attendees = function (frm, name, value ) {
 		});
 	frm.fields_dict['attendees'].grid.grid_buttons.find('.btn-custom').removeClass('btn-default').addClass('btn btn-xs btn-secondary grid-add-row');
 } 
+
+let mom_follow_up = function (frm, cdt, cdn){
+	/*
+	showing/hiding follow up section
+	output: checking/unchecking follow_up_needed field
+	 */
+	let d = locals[cdt][cdn];
+	if ( d.need_follow_up ){
+		frm.set_value( 'follow_up_needed', 1);//ticking follow_up_needed
+	}
+	else{
+		let flag = false;
+		frm.doc.actions.forEach(function(i){
+			if(i.need_follow_up){
+				flag = true;
+			}
+		})
+		if (flag == false){
+			frm.set_value( 'follow_up_needed', 0)
+		}
+	}
+}

--- a/minom/minutes_of_meeting/doctype/mom/mom.json
+++ b/minom/minutes_of_meeting/doctype/mom/mom.json
@@ -26,6 +26,11 @@
   "last_mom_name",
   "last_attendees",
   "last_actions",
+  "follow_up_section",
+  "follow_up_needed",
+  "user",
+  "remarks",
+  "reason_for_followup",
   "amended_from"
  ],
  "fields": [
@@ -153,12 +158,43 @@
    "fieldname": "get_user",
    "fieldtype": "Button",
    "label": "Get user"
+  },
+  {
+   "default": "0",
+   "fieldname": "follow_up_needed",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Follow Up Needed"
+  },
+  {
+   "fieldname": "follow_up_section",
+   "fieldtype": "Section Break",
+   "label": "Follow Up"
+  },
+  {
+   "depends_on": "eval: doc.follow_up_needed == 1",
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks"
+  },
+  {
+   "depends_on": "eval: doc.follow_up_needed == 1",
+   "fieldname": "reason_for_followup",
+   "fieldtype": "Small Text",
+   "label": "Reason for Followup"
+  },
+  {
+   "depends_on": "eval: doc.follow_up_needed == 1",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-08-23 11:46:14.398689",
+ "modified": "2022-08-23 14:21:20.699483",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "MOM",


### PR DESCRIPTION
## Feature description
merged actions table and pending actions table into one table
Creating MOM Followup from MOM for actions with on demand (follow up needed tasks)

## Analysis and design (optional)

MOM

![Screenshot from 2022-08-23 14-27-57](https://user-images.githubusercontent.com/105269688/186120551-32438ea1-64da-4b2d-aa9a-c60df3ef3f9a.png)

![Screenshot from 2022-08-23 14-28-36](https://user-images.githubusercontent.com/105269688/186120612-fbfdb67e-4a40-4fde-ab1c-7a75793f68bf.png)

![Screenshot from 2022-08-23 14-29-13](https://user-images.githubusercontent.com/105269688/186120658-6a093eaf-55e7-4902-8099-4fc3aadb8f4e.png)

MOM Follow Up

![Screenshot from 2022-08-23 14-29-41](https://user-images.githubusercontent.com/105269688/186120807-09deb48d-1a35-405a-93db-49639c50d202.png)

![Screenshot from 2022-08-23 14-29-52](https://user-images.githubusercontent.com/105269688/186120836-95d53e35-7b6b-429c-a188-6542c5a9792a.png)


## Solution description
creating mom follow up on submission of mom with follow up needed tasks.
creating task from actions table only if it is not an existing task.

## Was this feature tested on the browsers?
  - Chrome
