### PR TITLE
fix:filter of attendees

### DIFF
--- a/minom/minutes_of_meeting/doctype/mom_followup/mom_followup.json
+++ b/minom/minutes_of_meeting/doctype/mom_followup/mom_followup.json
@@ -56,6 +56,7 @@
   },
   {
    "fetch_from": "project.project_supervisor",
+   "fetch_if_empty": 1,
    "fieldname": "supervisor",
    "fieldtype": "Link",
    "label": "Supervisor",
@@ -63,6 +64,7 @@
   },
   {
    "fetch_from": "project.site_location",
+   "fetch_if_empty": 1,
    "fieldname": "site_location",
    "fieldtype": "Link",
    "label": "Site Location",
@@ -124,7 +126,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-08-22 16:55:56.129283",
+ "modified": "2022-08-24 12:55:01.279979",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "MOM Followup",


### PR DESCRIPTION
## Feature description
filtering the user field in attendees( on removal of row, when fetching users from the project by get user button) .
in mom follow up ,supervisor and site location field value is now fetched only if it is empty .
follow up section unchecked on change of project.

## Analysis and design (optional)
MOM
![Screenshot from 2022-08-24 17-24-48](https://user-images.githubusercontent.com/105269688/186413553-3ed9d594-26f8-470a-a821-1f664c82f075.png)

MOM Follow Up

![Screenshot from 2022-08-24 17-33-56](https://user-images.githubusercontent.com/105269688/186413702-2ab43baf-d774-44b9-ada3-373e25bf8839.png)



## Was this feature tested on the browsers?
  - Chrome
