### PR TITLE
fix:Configure MOM Followup reminder with in hours with followup type …

### DIFF
--- a/minom/hooks.py
+++ b/minom/hooks.py
@@ -124,6 +124,8 @@ scheduler_events = {
 	# ]
 }
 
+fixtures = ["MOM Settings"]
+
 # Testing
 # -------
 

--- a/minom/minutes_of_meeting/doctype/mom/mom.js
+++ b/minom/minutes_of_meeting/doctype/mom/mom.js
@@ -72,6 +72,9 @@ frappe.ui.form.on('MOM', {
 		frm.set_value('review_last_mom', 0);
 		frm.clear_table('attendees');
 		frm.set_value( 'follow_up_needed', 0)
+		frm.refresh_fields('attendees');
+		frm.refresh_fields('actions');
+
 	},
 
 	from_time: function (frm) {

--- a/minom/minutes_of_meeting/doctype/mom_settings/mom_settings.json
+++ b/minom/minutes_of_meeting/doctype/mom_settings/mom_settings.json
@@ -6,19 +6,25 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "notification_content"
+  "notification_content",
+  "notification_time_duration_for_mom_followup"
  ],
  "fields": [
   {
    "fieldname": "notification_content",
    "fieldtype": "Text",
    "label": "Notification content"
+  },
+  {
+   "fieldname": "notification_time_duration_for_mom_followup",
+   "fieldtype": "Time",
+   "label": "Notification time duration for MOM Followup"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-08-22 12:41:09.393622",
+ "modified": "2022-08-22 20:50:20.619489",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "MOM Settings",

--- a/minom/minutes_of_meeting/utils.py
+++ b/minom/minutes_of_meeting/utils.py
@@ -5,25 +5,39 @@ from frappe.utils import time_diff
 
 @frappe.whitelist()
 def send_mom_followup_notif():
+    '''
+        getting notification from creation of MOM Followup
+        output: get notification from MOM Followup
+    '''
+    mom_settings = frappe.get_doc('MOM Settings')
     mom_follow_ups = frappe.db.get_all(
         'MOM Followup', fields=['name', 'date', 'status_of_followup', 'user', 'supervisor'])
     for mom_followup in mom_follow_ups:
+        followup_date = mom_followup.date
+        now = datetime.now()
         if (mom_followup.status_of_followup == 'Pending'):
-            followup_date = mom_followup.date
-            now = datetime.now()
             if (time_diff(now, followup_date).days >= 1):
                 create_momf_pending_notification(mom_followup.name, mom_followup.user)
                 create_momf_pending_notification(mom_followup.name, mom_followup.supervisor)
-
+        if(mom_followup.status_of_followup != 'Cancelled'):
+            mom_settings_time = mom_settings.notification_time_duration_for_mom_followup
+            difference_in_hours = int(time_diff(now, followup_date).total_seconds()/3600)
+            if(time_diff(now, followup_date).days >= 1  or  difference_in_hours >= mom_settings_time):
+                create_momf_pending_notification(mom_followup.name, mom_followup.supervisor)
+                 
 
 @frappe.whitelist()
 def create_momf_pending_notification(mom_followup_id, recepient):
     mom_followup = frappe.get_doc('MOM Followup', mom_followup_id)
     notification_log = frappe.new_doc('Notification Log')
     notification_log.type = 'Alert'
-    notification_log.subject = mom_followup.name + ' is Pending'
-    notification_log.email_content = 'MOM Followup with id ' + mom_followup.name + ' of ' + mom_followup.mom + ' is still Pending. Take actions to Complete it ASAP.'
     notification_log.document_type = mom_followup.doctype
     notification_log.document_name = mom_followup.name
     notification_log.for_user = recepient
+    if (mom_followup.status_of_followup == 'Pending'):
+        notification_log.subject = mom_followup.name + ' is Pending'
+        notification_log.email_content = 'MOM Followup with id ' + mom_followup.name + ' of ' + mom_followup.mom + ' is still Pending. Take actions to Complete it ASAP.'
+    if (mom_followup.status_of_followup != 'Cancelled'):
+        notification_log.subject = mom_followup.name + ' is created'
+        notification_log.email_content = 'MOM Followup with id ' + mom_followup.name + ' of ' + mom_followup.mom + ' is created. Please check it!.'
     notification_log.save(ignore_permissions=True)


### PR DESCRIPTION
…or general configuration

## Feature description
Configure MOM Followup reminder with in hours with followup type or general configuration
## Output screenshots (optional)
![Screenshot from 2022-08-24 17-34-38](https://user-images.githubusercontent.com/105269795/186413820-847e2727-728a-4f1d-b645-29ef92ddf233.png)


## Was this feature tested on the browsers?
  - Chrome
  - Safari
