### PR TITLE
fix:random momf notifications

### DIFF
--- a/minom/hooks.py
+++ b/minom/hooks.py
@@ -114,15 +114,20 @@ scheduler_events = {
 	# "daily": [
 	# 	"minom.tasks.daily"
 	# ],
-	"hourly": [
-		"minom.minutes_of_meeting.utils.send_mom_followup_notif"
-	]
+	# "hourly": [
+	# 	"minom.minutes_of_meeting.utils.send_mom_followup_notif"
+	# ]
 	# "weekly": [
 	# 	"minom.tasks.weekly"
 	# ],
 	# "monthly": [
 	# 	"minom.tasks.monthly"
 	# ]
+	"cron": {
+        "0 8 * * *": [
+            "minom.minutes_of_meeting.utils.send_mom_followup_notif"
+        ]
+    }
 }
 
 fixtures = ["MOM Settings"]

--- a/minom/minutes_of_meeting/doctype/mom_followup/mom_followup.py
+++ b/minom/minutes_of_meeting/doctype/mom_followup/mom_followup.py
@@ -3,19 +3,16 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.desk.doctype.notification_settings.notification_settings import (
-	is_email_notifications_enabled_for_type,
-	is_notifications_enabled,
-	set_seen_value,)
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
-from email.utils import formataddr
 
 class MOMFollowup(Document):
-	def validate(self):
-		mom_settings = frappe.get_doc('MOM Settings')
+	def after_insert(self):
+		self.send_new_mom_notif()
+
+	def send_new_mom_notif(self):
+		"""method to send a notification when a new MOM Followup is created"""
 		notification_log = frappe.new_doc('Notification Log')
-		notification_log.subject = self.name +  ' MOM Followup is created'
-		notification_log.email_content = frappe.render_template(mom_settings.notification_content, {'mom_followup':self.name,'mom':self.mom})
+		notification_log.subject = 'New MOM Followup'
+		notification_log.email_content = 'An MOM Followup with ID ' + self.name + ' against ' + self.mom + ' has been created.'
 		notification_log.document_type = self.doctype
 		notification_log.document_name = self.name
 		notification_log.for_user = self.supervisor

--- a/minom/minutes_of_meeting/doctype/mom_settings/mom_settings.json
+++ b/minom/minutes_of_meeting/doctype/mom_settings/mom_settings.json
@@ -6,25 +6,25 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "notification_content",
-  "notification_time_duration_for_mom_followup"
+  "notification_interval",
+  "notification_content_pending_momf"
  ],
  "fields": [
   {
-   "fieldname": "notification_content",
-   "fieldtype": "Text",
-   "label": "Notification content"
+   "fieldname": "notification_interval",
+   "fieldtype": "Time",
+   "label": "Pending Notification for MOM Followup should be send after?"
   },
   {
-   "fieldname": "notification_time_duration_for_mom_followup",
-   "fieldtype": "Time",
-   "label": "Notification time duration for MOM Followup"
+   "fieldname": "notification_content_pending_momf",
+   "fieldtype": "Small Text",
+   "label": "Notification content for Pending MOM Followup"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-08-22 20:50:20.619489",
+ "modified": "2022-11-07 15:17:38.037728",
  "modified_by": "Administrator",
  "module": "MINutes Of Meeting",
  "name": "MOM Settings",


### PR DESCRIPTION
## Fix description
- Notifications of MOM Followup where being sent randomly, fixed it so that they will be only sent at appropriate time

## Areas affected and ensured
- MOM Followup
- MOM Settings

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Mozilla Firefox
